### PR TITLE
Fix GitHub streak and stats image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,14 @@ Hi I'm Antonio, a full-stack software engineer, devops engineer and selfhoster b
 
 ### GitHub Streaks
 
-[![GitHub Streak](https://streak-stats.demolab.com?user=ad-archer&hide_border=false&background=00000000&sideNums=777&currStreakNum=777&dates=EB5454&ring=EB5454&fire=EB5454&stroke=EB5454)](https://git.io/streak-stats)
-
+[![GitHub Streak](https://streak-stats.demolab.com/?user=ad-archer&currStreakLabel=EB5454&sideNums=EB5454hide_border=false&mode=weekly&background=00000000&sideLabels=EB5454&sideNums=777&currStreakNum=777&ring=EB5454&fire=EB5454&stroke=EB5454)
 ### Top Languages
 
 [![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=ad-archer&layout=compact&theme=dracula&bg_color=00000000&text_color=777&border=777&title_color=777)](https://github.com/ad-archer)
 
 ### GitHub Stats
 
-[![GitHub Stats](https://github-readme-stats.vercel.app/api?username=ad-archer&theme=dracula&show_icons=true&text_color=777&bg_color=00000000&title_color=bd93f9)](https://github.com/ad-archer)
+[![GitHub Stats](https://github-readme-stats.vercel.app/api?username=ad-archer&theme=dracula&show_icons=true&text_color=777mode=weekly&bg_color=00000000&title_color=bd93f9)](https://github.com/ad-archer)
 
 ## Activities
 


### PR DESCRIPTION
Updated GitHub streak and stats links in README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated profile visuals to use weekly mode for the GitHub Streak and GitHub Stats images.
  * Refreshed image URLs and parameters to improve clarity of weekly streaks and activity metrics.
  * Adjusted formatting options (labels, colors, and modes) for more readable stats.
  * Minor syntax tweaks to URL structure for consistency in rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->